### PR TITLE
Allow restore and playbac

### DIFF
--- a/Ezley.API.Commands/appsettings.Development.json
+++ b/Ezley.API.Commands/appsettings.Development.json
@@ -10,7 +10,7 @@
       "ViewContainer": "views",
       "SnapshotContainer": "snapshots",
       "Database": "esdemo",
-      "AuthKey": "aENKTvufKynrTcKWbVJH8iMIOR7KIfeh6YqFzN7epC5y3Ad0vVsHNp3UtcSELVL77UCfsTfdxlA12g1ola5PMA==",
-      "EndPointUri": "https://esdemo1.documents.azure.com:443/"
+      "AuthKey": "",
+      "EndPointUri": ""
     }
   }

--- a/Ezley.API.Commands/appsettings.Development.json
+++ b/Ezley.API.Commands/appsettings.Development.json
@@ -9,17 +9,8 @@
       "EventContainer": "events",
       "ViewContainer": "views",
       "SnapshotContainer": "snapshots",
-      "Database": "myCosmosDb",
-      "AuthKey": "[your auth key]",
-      "EndPointUri": "[your cosmosdb url]"
-    },
-    "Auth0": {
-      "Domain": "[your auth0 domain]",
-      "Audience": "https://[auth0 url]/api/v2/",
-      "ClientId": "[clientid]",
-      "ClientSecret": "[clientSecret]",
-      "Connection": "Username-Password-Authentication",
-      "Authority": "https://[yourAuth].auth0.com/"
-    },
-   
+      "Database": "esdemo",
+      "AuthKey": "aENKTvufKynrTcKWbVJH8iMIOR7KIfeh6YqFzN7epC5y3Ad0vVsHNp3UtcSELVL77UCfsTfdxlA12g1ola5PMA==",
+      "EndPointUri": "https://esdemo1.documents.azure.com:443/"
+    }
   }

--- a/Ezley.API.Requests/appsettings.Development.json
+++ b/Ezley.API.Requests/appsettings.Development.json
@@ -11,7 +11,7 @@
     "ViewContainer": "views",
     "SnapshotContainer": "snapshots",
     "Database": "esdemo",
-    "AuthKey": "aENKTvufKynrTcKWbVJH8iMIOR7KIfeh6YqFzN7epC5y3Ad0vVsHNp3UtcSELVL77UCfsTfdxlA12g1ola5PMA==",
-    "EndPointUri": "https://esdemo1.documents.azure.com:443/"
+    "AuthKey": "",
+    "EndPointUri": ""
   }
 }

--- a/Ezley.API.Requests/appsettings.Development.json
+++ b/Ezley.API.Requests/appsettings.Development.json
@@ -10,8 +10,8 @@
     "EventContainer": "events",
     "ViewContainer": "views",
     "SnapshotContainer": "snapshots",
-    "Database": "myCosmosDb",
-    "AuthKey": "[your auth key]",
-    "EndPointUri": "[your cosmosdb url]"
+    "Database": "esdemo",
+    "AuthKey": "aENKTvufKynrTcKWbVJH8iMIOR7KIfeh6YqFzN7epC5y3Ad0vVsHNp3UtcSELVL77UCfsTfdxlA12g1ola5PMA==",
+    "EndPointUri": "https://esdemo1.documents.azure.com:443/"
   }
 }

--- a/Ezley.ProjectionEngine/ProjectionBackgroundService.cs
+++ b/Ezley.ProjectionEngine/ProjectionBackgroundService.cs
@@ -49,9 +49,7 @@ namespace Ezley.ProjectionEngine
 
             // get datetime from epoch seconds
             _startDateTimeUtcEpochSeconds = long.Parse(configuration["Azure:ProjectionStartTimeUtcExclusive"]);
-            var epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-            _startDateTimeUtc = epoch.AddSeconds(_startDateTimeUtcEpochSeconds);
-            
+
             _logger = logger;
         }
        
@@ -68,7 +66,7 @@ namespace Ezley.ProjectionEngine
                     eventTypeResolver, viewRepo,
                     _eventsEndpointUri, _eventsAuthKey, _eventsDatabase, 
                     _leasesEndpointUri, _leasesAuthKey, _leasesDatabase, 
-                    _eventsContainer,_leasesContainer, _startDateTimeUtc
+                    _eventsContainer,_leasesContainer, _startDateTimeUtcEpochSeconds
                     );
                 
                 projectionEngine.RegisterProjection(new OrderProjection());

--- a/Ezley.ProjectionEngine/appsettings.Development.json
+++ b/Ezley.ProjectionEngine/appsettings.Development.json
@@ -9,18 +9,18 @@
   "Azure": {
     "EventsContainer": "events",
     "EventsDatabase": "esdemo",
-    "EventsAuthKey": "aENKTvufKynrTcKWbVJH8iMIOR7KIfeh6YqFzN7epC5y3Ad0vVsHNp3UtcSELVL77UCfsTfdxlA12g1ola5PMA==",
-    "EventsEndPointUri": "https://esdemo1.documents.azure.com:443/",
+    "EventsAuthKey": "",
+    "EventsEndPointUri": "",
     
     "LeasesContainer": "leases",
     "LeasesDatabase": "esdemo",
-    "LeasesAuthKey": "PKuACoVqONYkKGEPA6a1N3yzW5112qV7NDSnj0dyfI3aW0stNkJwdiBk90pqTMjLLPPAEyUP3zf74PjLCAZbBQ==",
-    "LeasesEndPointUri": "https://esdemorestore.documents.azure.com:443/",
+    "LeasesAuthKey": "",
+    "LeasesEndPointUri": "",
     
     "ViewsContainer": "views",
     "ViewsDatabase": "esdemo",
-    "ViewsAuthKey": "PKuACoVqONYkKGEPA6a1N3yzW5112qV7NDSnj0dyfI3aW0stNkJwdiBk90pqTMjLLPPAEyUP3zf74PjLCAZbBQ==",
-    "ViewsEndPointUri": "https://esdemorestore.documents.azure.com:443/",
+    "ViewsAuthKey": "",
+    "ViewsEndPointUri": "",
     
     "ProjectionStartTimeUtcExclusive": 1614310402
   }

--- a/Ezley.ProjectionEngine/appsettings.Development.json
+++ b/Ezley.ProjectionEngine/appsettings.Development.json
@@ -7,11 +7,21 @@
     }
   },
   "Azure": {
-    "EventContainer": "events",
-    "ViewContainer": "views",
-    "LeaseContainer": "leases",
-    "Database": "myCosmosDb",
-    "AuthKey": "[your auth key]",
-    "EndPointUri": "[your cosmosdb url]"
+    "EventsContainer": "events",
+    "EventsDatabase": "esdemo",
+    "EventsAuthKey": "aENKTvufKynrTcKWbVJH8iMIOR7KIfeh6YqFzN7epC5y3Ad0vVsHNp3UtcSELVL77UCfsTfdxlA12g1ola5PMA==",
+    "EventsEndPointUri": "https://esdemo1.documents.azure.com:443/",
+    
+    "LeasesContainer": "leases",
+    "LeasesDatabase": "esdemo",
+    "LeasesAuthKey": "PKuACoVqONYkKGEPA6a1N3yzW5112qV7NDSnj0dyfI3aW0stNkJwdiBk90pqTMjLLPPAEyUP3zf74PjLCAZbBQ==",
+    "LeasesEndPointUri": "https://esdemorestore.documents.azure.com:443/",
+    
+    "ViewsContainer": "views",
+    "ViewsDatabase": "esdemo",
+    "ViewsAuthKey": "PKuACoVqONYkKGEPA6a1N3yzW5112qV7NDSnj0dyfI3aW0stNkJwdiBk90pqTMjLLPPAEyUP3zf74PjLCAZbBQ==",
+    "ViewsEndPointUri": "https://esdemorestore.documents.azure.com:443/",
+    
+    "ProjectionStartTimeUtcExclusive": 1614256746
   }
 }

--- a/Ezley.ProjectionEngine/appsettings.Development.json
+++ b/Ezley.ProjectionEngine/appsettings.Development.json
@@ -22,6 +22,6 @@
     "ViewsAuthKey": "PKuACoVqONYkKGEPA6a1N3yzW5112qV7NDSnj0dyfI3aW0stNkJwdiBk90pqTMjLLPPAEyUP3zf74PjLCAZbBQ==",
     "ViewsEndPointUri": "https://esdemorestore.documents.azure.com:443/",
     
-    "ProjectionStartTimeUtcExclusive": 1614256746
+    "ProjectionStartTimeUtcExclusive": 1614310402
   }
 }

--- a/Ezley.ProjectionStore/Change.cs
+++ b/Ezley.ProjectionStore/Change.cs
@@ -7,5 +7,8 @@ namespace Ezley.ProjectionStore
     {
         [JsonProperty("_lsn")]
         public long LogicalSequenceNumber { get; set; }
+        
+        [JsonProperty("_ts")]
+        public long TimeStamp { get; set; }
     }
 }

--- a/Ezley.ProjectionStore/CosmosDb/CosmosDBProjectionEngine.cs
+++ b/Ezley.ProjectionStore/CosmosDb/CosmosDBProjectionEngine.cs
@@ -12,26 +12,49 @@ namespace Ezley.ProjectionStore
     {
         private readonly IEventTypeResolver _eventTypeResolver;
         private readonly IViewRepository _viewRepository;
-        private readonly string _endpointUrl;
-        private readonly string _authorizationKey;
-        private readonly string _databaseId;
+        private readonly string _leaseEndpointUrl;
+        private readonly string _leaseAuthorizationKey;
+        private readonly string _leaseDatabaseId;
+        private readonly string _eventEndpointUrl;
+        private readonly string _eventAuthorizationKey;
+        private readonly string _eventDatabaseId;
         private readonly string _eventContainerId;
         private readonly string _leaseContainerId;
         private readonly List<IProjection> _projections;
         private ChangeFeedProcessor _changeFeedProcessor;
+        private DateTime _startTimeUtc; // Sets the time (exclusive) to start looking for changes after.
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="eventTypeResolver"></param>
+        /// <param name="viewRepository"></param>
+        /// <param name="eventEndpointUrl"></param>
+        /// <param name="eventAuthorizationKey"></param>
+        /// <param name="eventDatabaseId"></param>
+        /// <param name="leaseEndpointUrl"></param>
+        /// <param name="leaseAuthorizationKey"></param>
+        /// <param name="leaseDatabaseId"></param>
+        /// <param name="eventContainerId"></param>
+        /// <param name="leaseContainerId"></param>
+        /// <param name="startTimeUtc">Sets the time (exclusive) to start looking for changes after.</param>
         public CosmosDBProjectionEngine(IEventTypeResolver eventTypeResolver, IViewRepository viewRepository,
-            string endpointUrl, string authorizationKey, string databaseId, string eventContainerId,
-            string leaseContainerId)
+            string eventEndpointUrl, string eventAuthorizationKey, string eventDatabaseId,
+            string leaseEndpointUrl, string leaseAuthorizationKey, string leaseDatabaseId, string eventContainerId,
+            string leaseContainerId, DateTime startTimeUtc)
         {
             _eventTypeResolver = eventTypeResolver;
             _viewRepository = viewRepository;
-            _endpointUrl = endpointUrl;
-            _authorizationKey = authorizationKey;
-            _databaseId = databaseId;
+            _eventEndpointUrl = eventEndpointUrl;
+            _eventAuthorizationKey = eventAuthorizationKey;
+            _eventDatabaseId = eventDatabaseId;
+            _leaseEndpointUrl = leaseEndpointUrl;
+            _leaseAuthorizationKey = leaseAuthorizationKey;
+            _leaseDatabaseId = leaseDatabaseId;
             _eventContainerId = eventContainerId;
             _leaseContainerId = leaseContainerId;
             _projections = new List<IProjection>();
+            _startTimeUtc = startTimeUtc;
         }
 
         public void RegisterProjection(IProjection projection)
@@ -41,16 +64,25 @@ namespace Ezley.ProjectionStore
 
         public Task StartAsync(string instanceName)
         {
-            CosmosClient client = new CosmosClient(_endpointUrl, _authorizationKey);
+            CosmosClient eventClient = new CosmosClient(_eventEndpointUrl, _eventAuthorizationKey);
+            CosmosClient leaseClient = new CosmosClient(_leaseEndpointUrl, _leaseAuthorizationKey);
 
-            Container eventContainer = client.GetContainer(_databaseId, _eventContainerId);
-            Container leaseContainer = client.GetContainer(_databaseId, _leaseContainerId);
+            Container eventContainer = eventClient.GetContainer(_eventDatabaseId, _eventContainerId);
+            Container leaseContainer = leaseClient.GetContainer(_leaseDatabaseId, _leaseContainerId);
 
+            var addminutes = 6 * 24 * 60;
+            var myTime1 =DateTimeOffset.FromUnixTimeSeconds(1614310402).UtcDateTime;
+            var myTime = DateTime.UnixEpoch;
+            myTime = myTime.AddSeconds(1614310402);
+            _startTimeUtc = _startTimeUtc.AddMinutes(addminutes);
             _changeFeedProcessor = eventContainer
                 .GetChangeFeedProcessorBuilder<Change>("Projection", HandleChangesAsync)
                 .WithInstanceName(instanceName)
                 .WithLeaseContainer(leaseContainer)
-                .WithStartTime(new DateTime(2020, 5, 1, 0, 0, 0, DateTimeKind.Utc))
+                // .WithStartTime(new DateTime(2020, 5, 1, 0, 0, 0, DateTimeKind.Utc))
+                //.WithStartTime(_startTimeUtc)
+                //.WithStartTime(DateTimeOffset.FromUnixTimeSeconds(1614256746).UtcDateTime)
+                .WithStartTime(myTime)
                 .Build();
 
             return _changeFeedProcessor.StartAsync();
@@ -63,8 +95,13 @@ namespace Ezley.ProjectionStore
 
         private async Task HandleChangesAsync(IReadOnlyCollection<Change> changes, CancellationToken cancellationToken)
         {
-            foreach (var change in changes)
+            long epoch = 1614310402;
+            var myTime =DateTimeOffset.FromUnixTimeSeconds(epoch).UtcDateTime;
+            var newChanges = changes.Where(x => x.TimeStamp > epoch).ToList();
+            
+            foreach (var change in newChanges)
             {
+              //  throw new ApplicationException();
                 var @event = change.GetEvent(_eventTypeResolver);
 
                 var subscribedProjections = _projections

--- a/Ezley.ProjectionStore/View.cs
+++ b/Ezley.ProjectionStore/View.cs
@@ -35,6 +35,15 @@ namespace Ezley.ProjectionStore
 
             return change.LogicalSequenceNumber > LogicalCheckpoint.LogicalSequenceNumber;
         }
+        public bool IsNewerThanTimeStamp(Change change)
+        {
+            if (change.TimeStamp == LogicalCheckpoint.TimeStamp)
+            {
+                return !LogicalCheckpoint.ItemIds.Contains(change.Id);
+            }
+
+            return change.LogicalSequenceNumber > LogicalCheckpoint.LogicalSequenceNumber;
+        }
 
         public void UpdateCheckpoint(Change change)
         {

--- a/Ezley.ProjectionStore/ViewCheckpoint.cs
+++ b/Ezley.ProjectionStore/ViewCheckpoint.cs
@@ -13,6 +13,9 @@ namespace Ezley.ProjectionStore
 
         [JsonProperty("lsn")]
         public long LogicalSequenceNumber { get; set; }
+        
+        [JsonProperty("_ts")]
+        public long TimeStamp { get; set; }
 
         [JsonProperty("itemIds")]
         public List<string> ItemIds { get; }

--- a/Ezley.Testing/OrderTest.cs
+++ b/Ezley.Testing/OrderTest.cs
@@ -146,7 +146,7 @@ namespace Ezley.Testing
                     _testConfig.EventsAuthKey, _testConfig.EventsDatabase, _testConfig.EventContainer);
 
                 var snapshotStore = new CosmosSnapshotStore(_testConfig.SnapshotsEndpointUri,
-                    _testConfig.SnapshotsEndpointUri,
+                    _testConfig.SnapshotsAuthKey,
                     _testConfig.SnapshotsDatabase, _testConfig.SnapshotsContainer);
                 return new OrderSystemRepository(eventStore, snapshotStore);
             }

--- a/Ezley.Testing/OrderTest.cs
+++ b/Ezley.Testing/OrderTest.cs
@@ -142,21 +142,20 @@ namespace Ezley.Testing
             {
                 var eventStore = new CosmosDBEventStore(
                     eventTypeResolver,
-                    _testConfig.EndpointUri,
-                    _testConfig.AuthKey, _testConfig.Database, _testConfig.EventContainer);
+                    _testConfig.EventsEndpointUri,
+                    _testConfig.EventsAuthKey, _testConfig.EventsDatabase, _testConfig.EventContainer);
 
-                var snapshotStore = new CosmosSnapshotStore(_testConfig.EndpointUri,
-                    _testConfig.AuthKey,
-                    _testConfig.Database, _testConfig.SnapshotContainer);
+                var snapshotStore = new CosmosSnapshotStore(_testConfig.SnapshotsEndpointUri,
+                    _testConfig.SnapshotsEndpointUri,
+                    _testConfig.SnapshotsDatabase, _testConfig.SnapshotsContainer);
                 return new OrderSystemRepository(eventStore, snapshotStore);
-
             }
         }
        
         private CosmosDBViewRepository GetViewRepository()
         {
-            return new CosmosDBViewRepository(_testConfig.EndpointUri, _testConfig.AuthKey,
-                _testConfig.Database, _testConfig.ViewContainer);
+            return new CosmosDBViewRepository(_testConfig.ViewsEndpointUri, _testConfig.ViewsAuthKey,
+                _testConfig.ViewsDatabase, _testConfig.ViewsContainer);
         }
     }
 }

--- a/Ezley.Testing/TestConfig.cs
+++ b/Ezley.Testing/TestConfig.cs
@@ -1,31 +1,38 @@
+using System;
+
 namespace Ezley.Testing
 {
     public partial class TestConfig
     {
+        // monitor changefeed startTime Exclusive (start after this).
+        public long StartTimeEpoch = (int)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds;
+        
         public readonly bool UseInMemoryEventStore = false;
-        public readonly string EventsEndpointUri = "https://esdemo2.documents.azure.com:443/";
+        public readonly string EventsEndpointUri = "https://esdemo1.documents.azure.com:443/";
         public readonly string EventsDatabase = "esdemo";
         public readonly string EventsAuthKey = 
-            "soVzlHrvy6wgipZOiDnXOFlyojfXAtyCvCpJgVsT3JpyzFiCIHNtgA5cZ3cV8prZ9iJjv9RFwaWm2Mw9dIvHyw==";
+            "aENKTvufKynrTcKWbVJH8iMIOR7KIfeh6YqFzN7epC5y3Ad0vVsHNp3UtcSELVL77UCfsTfdxlA12g1ola5PMA==";
         public readonly string EventContainer = "events";
         
-        public readonly string LeasesEndpointUri = "https://esdemo2.documents.azure.com:443/";
+        public readonly string LeasesEndpointUri = "https://esdemo1.documents.azure.com:443/";
         public readonly string LeasesDatabase = "esdemo";
         public readonly string LeasesAuthKey = 
-            "soVzlHrvy6wgipZOiDnXOFlyojfXAtyCvCpJgVsT3JpyzFiCIHNtgA5cZ3cV8prZ9iJjv9RFwaWm2Mw9dIvHyw==";
+            "aENKTvufKynrTcKWbVJH8iMIOR7KIfeh6YqFzN7epC5y3Ad0vVsHNp3UtcSELVL77UCfsTfdxlA12g1ola5PMA==";
         public readonly string LeasesContainer = "leases";
         
-        public readonly string ViewsEndpointUri = "https://esdemo2.documents.azure.com:443/";
+        public readonly string ViewsEndpointUri = "https://esdemo1.documents.azure.com:443/";
         public readonly string ViewsDatabase = "esdemo";
         public readonly string ViewsAuthKey = 
-            "soVzlHrvy6wgipZOiDnXOFlyojfXAtyCvCpJgVsT3JpyzFiCIHNtgA5cZ3cV8prZ9iJjv9RFwaWm2Mw9dIvHyw==";
+            "aENKTvufKynrTcKWbVJH8iMIOR7KIfeh6YqFzN7epC5y3Ad0vVsHNp3UtcSELVL77UCfsTfdxlA12g1ola5PMA==";
         public readonly string ViewsContainer = "views";
         
-        public readonly string SnapshotsEndpointUri = "https://esdemo2.documents.azure.com:443/";
+        public readonly string SnapshotsEndpointUri = "https://esdemo1.documents.azure.com:443/";
         public readonly string SnapshotsDatabase = "esdemo";
         public readonly string SnapshotsAuthKey = 
-            "soVzlHrvy6wgipZOiDnXOFlyojfXAtyCvCpJgVsT3JpyzFiCIHNtgA5cZ3cV8prZ9iJjv9RFwaWm2Mw9dIvHyw==";
+            "aENKTvufKynrTcKWbVJH8iMIOR7KIfeh6YqFzN7epC5y3Ad0vVsHNp3UtcSELVL77UCfsTfdxlA12g1ola5PMA==";
         public readonly string SnapshotsContainer = "snapshots";
+        
+        
        
     }
 }

--- a/Ezley.Testing/TestConfig.cs
+++ b/Ezley.Testing/TestConfig.cs
@@ -3,16 +3,29 @@ namespace Ezley.Testing
     public partial class TestConfig
     {
         public readonly bool UseInMemoryEventStore = false;
-        public readonly string EndpointUri = "https://yourdb.documents.azure.com:443/";
-        public readonly string Database = "yourdb";
-
-        public readonly string AuthKey = 
-            "yourkey==";
-
+        public readonly string EventsEndpointUri = "https://esdemo2.documents.azure.com:443/";
+        public readonly string EventsDatabase = "esdemo";
+        public readonly string EventsAuthKey = 
+            "soVzlHrvy6wgipZOiDnXOFlyojfXAtyCvCpJgVsT3JpyzFiCIHNtgA5cZ3cV8prZ9iJjv9RFwaWm2Mw9dIvHyw==";
         public readonly string EventContainer = "events";
+        
+        public readonly string LeasesEndpointUri = "https://esdemo2.documents.azure.com:443/";
+        public readonly string LeasesDatabase = "esdemo";
+        public readonly string LeasesAuthKey = 
+            "soVzlHrvy6wgipZOiDnXOFlyojfXAtyCvCpJgVsT3JpyzFiCIHNtgA5cZ3cV8prZ9iJjv9RFwaWm2Mw9dIvHyw==";
         public readonly string LeasesContainer = "leases";
-        public readonly string ViewContainer = "views";
-        public readonly string SnapshotContainer = "snapshots";
- 
+        
+        public readonly string ViewsEndpointUri = "https://esdemo2.documents.azure.com:443/";
+        public readonly string ViewsDatabase = "esdemo";
+        public readonly string ViewsAuthKey = 
+            "soVzlHrvy6wgipZOiDnXOFlyojfXAtyCvCpJgVsT3JpyzFiCIHNtgA5cZ3cV8prZ9iJjv9RFwaWm2Mw9dIvHyw==";
+        public readonly string ViewsContainer = "views";
+        
+        public readonly string SnapshotsEndpointUri = "https://esdemo2.documents.azure.com:443/";
+        public readonly string SnapshotsDatabase = "esdemo";
+        public readonly string SnapshotsAuthKey = 
+            "soVzlHrvy6wgipZOiDnXOFlyojfXAtyCvCpJgVsT3JpyzFiCIHNtgA5cZ3cV8prZ9iJjv9RFwaWm2Mw9dIvHyw==";
+        public readonly string SnapshotsContainer = "snapshots";
+       
     }
 }

--- a/Ezley.Testing/TestConfig.cs
+++ b/Ezley.Testing/TestConfig.cs
@@ -8,28 +8,28 @@ namespace Ezley.Testing
         public long StartTimeEpoch = (int)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds;
         
         public readonly bool UseInMemoryEventStore = false;
-        public readonly string EventsEndpointUri = "https://esdemo1.documents.azure.com:443/";
+        public readonly string EventsEndpointUri = "";
         public readonly string EventsDatabase = "esdemo";
         public readonly string EventsAuthKey = 
-            "aENKTvufKynrTcKWbVJH8iMIOR7KIfeh6YqFzN7epC5y3Ad0vVsHNp3UtcSELVL77UCfsTfdxlA12g1ola5PMA==";
+            "";
         public readonly string EventContainer = "events";
         
-        public readonly string LeasesEndpointUri = "https://esdemo1.documents.azure.com:443/";
+        public readonly string LeasesEndpointUri = "";
         public readonly string LeasesDatabase = "esdemo";
         public readonly string LeasesAuthKey = 
-            "aENKTvufKynrTcKWbVJH8iMIOR7KIfeh6YqFzN7epC5y3Ad0vVsHNp3UtcSELVL77UCfsTfdxlA12g1ola5PMA==";
+            "";
         public readonly string LeasesContainer = "leases";
         
-        public readonly string ViewsEndpointUri = "https://esdemo1.documents.azure.com:443/";
+        public readonly string ViewsEndpointUri = "";
         public readonly string ViewsDatabase = "esdemo";
         public readonly string ViewsAuthKey = 
-            "aENKTvufKynrTcKWbVJH8iMIOR7KIfeh6YqFzN7epC5y3Ad0vVsHNp3UtcSELVL77UCfsTfdxlA12g1ola5PMA==";
+            "";
         public readonly string ViewsContainer = "views";
         
-        public readonly string SnapshotsEndpointUri = "https://esdemo1.documents.azure.com:443/";
+        public readonly string SnapshotsEndpointUri = "";
         public readonly string SnapshotsDatabase = "esdemo";
         public readonly string SnapshotsAuthKey = 
-            "aENKTvufKynrTcKWbVJH8iMIOR7KIfeh6YqFzN7epC5y3Ad0vVsHNp3UtcSELVL77UCfsTfdxlA12g1ola5PMA==";
+            "";
         public readonly string SnapshotsContainer = "snapshots";
         
         

--- a/Ezley.Testing/_RunProjectionEngine.cs
+++ b/Ezley.Testing/_RunProjectionEngine.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Ezley.Events;
 using Ezley.Projections;
@@ -15,15 +16,18 @@ namespace Ezley.Testing
         {
             var eventTypeResolver = new EventTypeResolver();
             var viewRepo = new CosmosDBViewRepository(
-                _testConfig.EndpointUri, 
-                _testConfig.AuthKey,
-                _testConfig.Database,
-                _testConfig.ViewContainer);
+                _testConfig.ViewsEndpointUri, 
+                _testConfig.ViewsAuthKey,
+                _testConfig.ViewsDatabase,
+                _testConfig.ViewsContainer);
 
-            var projectionEngine = new CosmosDBProjectionEngine(eventTypeResolver,
-                viewRepo,
-                _testConfig.EndpointUri, _testConfig.AuthKey, _testConfig.Database,
-                _testConfig.EventContainer, _testConfig.LeasesContainer);
+            // start from the beginning
+            var startTimeUtc = DateTime.MinValue;
+           
+            var projectionEngine = new CosmosDBProjectionEngine(eventTypeResolver, viewRepo,
+                _testConfig.EventsEndpointUri, _testConfig.EventsAuthKey, _testConfig.EventsDatabase,
+                _testConfig.LeasesEndpointUri, _testConfig.LeasesAuthKey, _testConfig.LeasesDatabase,
+                _testConfig.EventContainer, _testConfig.LeasesContainer, startTimeUtc);
             
             projectionEngine.RegisterProjection(new OrderProjection());
             projectionEngine.RegisterProjection(new PendingOrdersProjection());

--- a/Ezley.Testing/_RunProjectionEngine.cs
+++ b/Ezley.Testing/_RunProjectionEngine.cs
@@ -20,14 +20,11 @@ namespace Ezley.Testing
                 _testConfig.ViewsAuthKey,
                 _testConfig.ViewsDatabase,
                 _testConfig.ViewsContainer);
-
-            // start from the beginning
-            var startTimeUtc = DateTime.MinValue;
-           
+            
             var projectionEngine = new CosmosDBProjectionEngine(eventTypeResolver, viewRepo,
                 _testConfig.EventsEndpointUri, _testConfig.EventsAuthKey, _testConfig.EventsDatabase,
                 _testConfig.LeasesEndpointUri, _testConfig.LeasesAuthKey, _testConfig.LeasesDatabase,
-                _testConfig.EventContainer, _testConfig.LeasesContainer, startTimeUtc);
+                _testConfig.EventContainer, _testConfig.LeasesContainer, _testConfig.StartTimeEpoch);
             
             projectionEngine.RegisterProjection(new OrderProjection());
             projectionEngine.RegisterProjection(new PendingOrdersProjection());


### PR DESCRIPTION
If you need to restore a views database due to any reason, and then playback events to it from a point in time to the present, you can now do so.

Point your Leases connection to a new clean container.
Point your Views connection to a restored view container.
Point your Events to your live events container. 

It will create a new lease subscription in the empty leases db, and start to add events to your Views database that occurred AFTER the start time in the config file.